### PR TITLE
Add Requesty as an LLM provider

### DIFF
--- a/Agent/Services/LLMProviderSetup.swift
+++ b/Agent/Services/LLMProviderSetup.swift
@@ -7,7 +7,7 @@ enum LLMProviderSetup {
 
     static func registerAllProviders() {
         LLMRegistry.shared.registerAll([
-            claude, codex, openAI, gemini, grok, mistral, codestral, vibe, deepSeek, huggingFace, miniMax, zAI, bigModel, qwen, openRouter,
+            claude, codex, openAI, gemini, grok, mistral, codestral, vibe, deepSeek, huggingFace, miniMax, zAI, bigModel, qwen, openRouter, requesty,
             ollama, localOllama, vLLM, lmStudio, appleIntelligence
         ])
     }
@@ -78,6 +78,16 @@ enum LLMProviderSetup {
         endpoint: LLMEndpoint(
             chatURL: "https://openrouter.ai/api/v1/chat/completions",
             modelsURL: "https://openrouter.ai/api/v1/models"
+        ),
+        capabilities: [.streaming, .tools, .vision, .systemPrompt]
+    )
+
+    static let requesty = LLMProviderConfig(
+        id: "requesty", displayName: "Requesty",
+        kind: .cloudAPI, apiProtocol: .openAI,
+        endpoint: LLMEndpoint(
+            chatURL: "https://router.requesty.ai/v1/chat/completions",
+            modelsURL: "https://router.requesty.ai/v1/models"
         ),
         capabilities: [.streaming, .tools, .vision, .systemPrompt]
     )


### PR DESCRIPTION
This adds [Requesty](https://requesty.ai) as a provider, mirroring the existing OpenRouter provider.

Requesty (`https://router.requesty.ai/v1`) is an OpenAI-compatible LLM router.

Change: a `requesty` `LLMProviderConfig` in `LLMProviderSetup.swift` (registered in `registerAllProviders`), mirroring the `openRouter`/`huggingFace` OpenAI-compatible cloud entries — the file's documented extension point for adding a provider.

Model naming is `provider/model`. `swiftc -parse` clean. I scoped this to the modern `LLMRegistry` path and left the legacy provider surface untouched; happy to extend further if you'd like.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.