### PR TITLE
feat(mcp): add Parallel Search preset

### DIFF
--- a/Agent/MCP/MCPPresets.swift
+++ b/Agent/MCP/MCPPresets.swift
@@ -19,5 +19,11 @@ enum MCPPresets {
                 command: "/Applications/xcf.app/Contents/MacOS/xcf server"
             )
         },
+        MCPPreset(id: "parallel.search", menuLabel: "Parallel Search — Web Search & Fetch") {
+            MCPServerConfig(
+                name: "Parallel Search",
+                url: "https://search.parallel.ai/mcp"
+            )
+        },
     ]
 }


### PR DESCRIPTION
The MCP settings already provide a preset menu, but adding a remote search server still requires entering its URL by hand. This adds a no-key Parallel Search option to that existing flow.

## What changed

- Added a `Parallel Search — Web Search & Fetch` preset using the existing HTTP MCP configuration
- Pointed it at `https://search.parallel.ai/mcp` with no headers or credentials
- Left the built-in search providers, fallbacks, and current xcf.ai preset unchanged

## Validation

- `swiftc -parse Agent/MCP/MCPPresets.swift Agent/MCP/MCPConfig.swift`
- `git diff --check`
- Confirmed the patch changes only `Agent/MCP/MCPPresets.swift`

A full Xcode build was not run because this host has Command Line Tools active rather than a full Xcode installation.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.