### PR TITLE
docs(faq): add Setup & Providers section (closes #30)

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -27,6 +27,30 @@ Any Mac running macOS 26 or later. Apple Silicon (M1/M2/M3/M4) recommended. 32GB
 
 ---
 
+## Setup & Providers
+
+### Which provider is cheapest to start with?
+**Z.ai** is the recommended starting point — it has the fastest signup, GLM-5.1 is its default model (nothing to provision), and it runs at pennies per million tokens. GLM-5.1 also runs on the other cheap providers (Hugging Face, BigModel, and Ollama Cloud). See the "Cheap GLM setup" note in the README Quick Start.
+
+### How do I run Agent! fully local (Ollama / LM Studio)?
+Both are self-hosted, offline, and need no account:
+- **Local Ollama** — run the Ollama daemon, then in Settings pick **Local Ollama** as your provider.
+- **LM Studio** — the easiest GUI for local models; start its local server and select **LM Studio** in Settings.
+
+Only models that fit your hardware run well: a 30B+ model at usable speed effectively needs an M2/M3/M4 Ultra (64–128GB unified memory) or a Linux box with 24GB+ VRAM. For GLM specifically, only **GLM-4.7-Turbo (32B)** fits consumer hardware locally; GLM-5 / GLM-5.1 are too large (~1.6TB) and should be used via the cloud providers. "Local/free" providers are free only in the API-fee sense — if you don't already own the hardware, the cheap cloud paths (Z.ai, BigModel, Hugging Face, DeepSeek, Ollama Cloud) are far cheaper than buying it.
+
+### Why won't the Launch Agent / Daemon register on my build from source?
+Because a build without an Apple Development Team is **ad-hoc signed**, and `SMAppService` requires a Team ID to register the Launch Agent/Daemon helpers. Everything else still works: the LLM loop, all tools, Accessibility, AppleScript, shell, and MCP. To get the helpers, open `Agent.xcodeproj` in Xcode, select the **Agent** scheme, set your own Development Team, then Build & Run and approve the helper when prompted.
+
+### What permissions does Agent! need, and how do I grant them?
+Agent! requests permissions **on-demand** when a feature is first used, not all at once — you can deny any one and still use the rest. The common ones (all under System Settings → Privacy & Security):
+- **Accessibility** — click buttons, type text, and control other apps.
+- **Screen Recording** — see what's on screen for visual automation.
+- **Automation** — control apps via Apple Events.
+- **Full Disk Access** — required only for **iMessage remote control**, so Agent! can read `~/Library/Messages/chat.db` directly. Enable Agent! under System Settings → Privacy & Security → Full Disk Access.
+
+---
+
 ## Security Questions
 
 > **Note:** This section addresses concerns raised in GitHub Issues regarding security architecture. Agent! follows Apple's official patterns for privileged helper tools.


### PR DESCRIPTION
Closes #30.

## What

Adds a **Setup & Providers** section to `docs/FAQ.md` with four new Q&A entries covering the common onboarding questions from the issue. Every answer is sourced from the README / CONTRIBUTING — no guessing.

## New entries

1. **Which provider is cheapest to start with?** — Z.ai / GLM-5.1 as the recommended start, plus the other cheap GLM providers (from the README "Cheap GLM setup" note).
2. **How do I run Agent! fully local (Ollama / LM Studio)?** — how to select each in Settings, with the honest hardware caveat that "local/free" is free only in the API-fee sense (from the README local-providers table + note).
3. **Why won't the Launch Agent / Daemon register on my build from source?** — ad-hoc signing has no Team ID, so `SMAppService` can't register the helpers; everything else still works. Points to the Xcode + Development Team path (from CONTRIBUTING / README build steps).
4. **What permissions does Agent! need, and how do I grant them?** — Accessibility, Screen Recording, Automation, and Full Disk Access (the last required only for iMessage's `chat.db`), noting permissions are requested on-demand (from the README permissions/iMessage sections).

## Definition of done

- [x] At least 2 new accurate Q&A entries in `docs/FAQ.md` (this adds 4)
- [x] Matches the existing FAQ format
- [x] Each answer verified against the README / CONTRIBUTING, not guessed

Docs-only change. First-time contributor — happy to trim or reword any entry.
